### PR TITLE
Use the `group` configuration option

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,21 +55,13 @@
                 company: "W3C", companyURL: "", w3cid: 3439 },
           ],
 
-          wg:           "Internationalization Working Group",
-          wgURI:        "https://www.w3.org/International/core/",
-          
+          group: "i18n",
+
           //wgPublicList: "public-i18n-cjk",
 		  github: "w3c/klreq",
 		  
 		  
 		  // subjectPrefix: '[klreq] ',
-          
-          // URI of the patent status for this WG, for Rec-track documents
-          // !!!! IMPORTANT !!!!
-          // This is important for Rec-track documents, do not copy a patent URI from a random
-          // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
-          // Team Contact.
-          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/32113/status",
       };
     </script>
 </head>


### PR DESCRIPTION
The wg, wgId, wgURI, and wgPatentURI options are deprecated in favour of
“group”.

See https://lists.w3.org/Archives/Public/spec-prod/2020JulSep/0002.html