### PR TITLE
Add a hyphen usage not required in a Hangul word

### DIFF
--- a/index.html
+++ b/index.html
@@ -1198,8 +1198,8 @@
         <li>
           <p its-locale-filter-list="en" lang="en">Line Breaking Rules in Hangul.</p>
           <p its-locale-filter-list="ko" lang="ko">한글 단위 줄 나눔 기준</p>
-          <p its-locale-filter-list="en" lang="en">If a line ends in Hangul, line breaking is done on character or word basis.  The user can decide which approach to use on a paragraph-by-paragraph basis, or for the whole document.</p>
-          <p its-locale-filter-list="ko" lang="ko">각 줄의 마지막에 한글이 올 때 줄 나눔 기준을 “글자” 또는 “어절” 단위로 한다. 문서 작성자가 “글자” 또는 “어절” 단위의 줄 나눔 기준을 지정할 수 있다.</p>
+          <p its-locale-filter-list="en" lang="en">When a line ends in Hangul, line breaking can be based on characters or words. The author can decide which approach to use, either for the whole document or on a paragraph-by-paragraph basis. Unlike Latin scripts, No hyphen is added when a line breaks within a Hangul word.</p>
+          <p its-locale-filter-list="ko" lang="ko">한글 텍스트의 줄바꿈은 글자 또는 단어(어절)를 기준으로 이루어질 수 있다. 저작자는 이를 문단별로 적용할지 또는 문서 전체에 적용할지를 결정할 수 있다. 라틴 문자와 달리 한글은 단어 중간에서 줄이 바뀌더라도 하이픈(-)을 사용하지 않는다.</p>
           <figure> <img src="images/char-vs-word.png" alt="" />
             <figcaption><span its-locale-filter-list="en" lang="en">Word-based (on the left) vs. character-based (on the right) line breaks.</span> <span its-locale-filter-list="ko" lang="ko">어절단위 줄 나눔(왼쪽)과 글자단위 줄 나눔(오른쪽)</span></figcaption>
           </figure>


### PR DESCRIPTION
This PR updates the line breaking rule in a Hangul word.
Resolves #8


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/anawhj/klreq/pull/66.html" title="Last updated on Dec 13, 2025, 5:51 AM UTC (f21b65f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/klreq/66/f9529dc...anawhj:f21b65f.html" title="Last updated on Dec 13, 2025, 5:51 AM UTC (f21b65f)">Diff</a>