### PR TITLE
Add note on full-width quote in figure 31 and remove #11 issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -991,7 +991,10 @@
           <figure> <img src="ko/images/4-17.png" alt="" />
             <figcaption><span its-locale-filter-list="en" lang="en">Brackets and quotation marks in vertical and horizontal writing</span> <span its-locale-filter-list="ko" lang="ko">가로짜기 및 세로짜기의 낫표 사용</span></figcaption>
           </figure>
-          <p class="issue">See <a href="https://github.com/w3c/klreq/issues/11">https://github.com/w3c/klreq/issues/11</a></p>
+          <div class="note" id="n1">
+            <p its-locale-filter-list="en" lang="en">In Figure 31 above, the quotation marks are rendered as full-width, creating whitespace between the quote and the following character. Proportional rendering, supported by modern fonts, typically eliminates this whitespace.</p>
+            <p its-locale-filter-list="ko" lang="ko">위의 Figure 31에서는 따옴표가 전각문자로 렌더링되어 따옴표와 그 뒤의 문자 사이에 불필요한 여백이 존재합니다. 현대적인 한글 폰트에서 지원하는 가변 렌더링 방식은 이러한 여백이 발생하지 않습니다.</p>
+          </div>
         </li>
       </ol>
     </section>


### PR DESCRIPTION
Added a note on full-width quotation marks rendering in figure 31 Removed #11 issue by the addition above


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/anawhj/klreq/pull/69.html" title="Last updated on Jan 10, 2026, 6:56 AM UTC (462326d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/klreq/69/f44878b...anawhj:462326d.html" title="Last updated on Jan 10, 2026, 6:56 AM UTC (462326d)">Diff</a>