### PR TITLE
Add lang="en" to the TOC nav text

### DIFF
--- a/script.js
+++ b/script.js
@@ -112,10 +112,29 @@
         }
       });
     }
+    function updateTOCLang() {
+      // Show the same arrow appearance regardless of the languages
+      const arrowSpans = document.querySelectorAll("#toc-nav a span:first-child");
+      arrowSpans.forEach(el => {
+        if (!el.hasAttribute("lang")) {
+          el.setAttribute("lang", "en");
+        }
+      });
+      // Register an MutationObserver for the language sync
+      const tocNav = document.querySelector("#toc-nav");
+      if (tocNav && tocNav.dataset.isObserved !== "true") {
+        const tocNavObserver = new MutationObserver(() => {
+          updateTOCLang();
+        });
+        tocNavObserver.observe(tocNav, { childList: true, subtree: true, attributes: true });
+        tocNav.dataset.isObserved = "true";
+      }
+    }
     window.switchLang = function(lang) {
       toggle$rootClass(lang);
       showAndHideLang(lang);
       replaceBoilerplateText(lang);
+      updateTOCLang();
     };
     function addLangAttr() {
       toggle$rootClass("all");


### PR DESCRIPTION
In MacOS, the arrow symbol appearance is shown differently when switching the language between English and Korean.
Thus, lang="en" is added to TOC navigation text for the consistent arrow symbol appearance regardless of the languages.