### PR TITLE
Translate required sections to KR

### DIFF
--- a/new.html
+++ b/new.html
@@ -123,7 +123,7 @@
 </ul>
 
 <p its-locale-filter-list="en" lang="en">In 2026, the document contents were reorganised to match the standard set of headings used for the W3C's Language Enablement framework by Richard Ishida.  Additional content was then added, drawing on contributions by ...</p>
-<p its-locale-filter-list="ko" lang="ko">2026년에 리처드 이시다(Richard Ishida)가 W3C의 언어 지원 프레임워크에서 사용하는 표준 헤드라인 세트에 맞춰 문서 내용을 재구성했습니다. 이후 ...의 기여를 바탕으로 추가 내용이 더해졌습니다.</p>
+<p its-locale-filter-list="ko" lang="ko">2026년 초, Richard Ishida가 W3C의 언어 지원 프레임워크에서 사용하는 표준 헤드라인 세트에 맞춰 문서 내용을 재구성했습니다. 이후 ...의 기여를 바탕으로 추가 내용이 더해졌습니다.</p>
 </section>
 
 
@@ -152,7 +152,7 @@
 <h3><span its-locale-filter-list="en" lang="en">How this Document was Created</span> <span its-locale-filter-list="ko" lang="ko">문서가 작성된 방법</span></h3>
 
 <p its-locale-filter-list="en" lang="en">The contents of this document are related to the Korean writing system, so all discussions took place in Korean, and were then translated into English once the document had been finished.</p>
-<p its-locale-filter-list="ko" lang="ko">본 문서를 개발하기 위해서 언급되는 내용은 한국어 시스템과 연관 있는 내용이므로, 모든 논의는 한국어로 진행되었으며, 개발된 한국어 문서를 기반으로 영문으로 번역되었다. </p>
+<p its-locale-filter-list="ko" lang="ko">본 문서를 개발하기 위해서 언급되는 내용은 한국어 시스템과 연관 있는 내용이므로, 모든 논의는 한국어로 진행되었으며 개발된 한국어 문서를 기반으로 영문으로 번역되었다. </p>
 
 <p its-locale-filter-list="en" lang="en">The technical terms for discussing and describing the Korean writing system were carefully selected after considering  potential differences in nuance even if a direct translation exists, and in some parts  they were described in both languages so the discussion can be continued in the future. Also many figures are included to promote understanding for  certain parts that are hard to describe in English.</p>
 <p its-locale-filter-list="ko" lang="ko">한국어 시스템에 대한 논의와 기술 시 기술적인 용어에 대해서는 해당 한국어를 의미하는 영어 단어가 존재한다 하더라도 주의를 기울여 그 두 언어 사이에 존재할 수 있는 잠재적인 차이점과 뉘앙스에 대해 검토하였으며, 한국어와 영어를 동시에 표현하여 향후 논의를 지속할 수 있도록 하였다. 또한 많은 그림을 삽입하여 영어로 표현하기 힘든 부분에 대해서 가능한 쉽게 정리하는 노력을 하였다.</p>
@@ -720,7 +720,7 @@
 </h3>
 
 <p its-locale-filter-list="en" lang="en">Unlike many ‘complex scripts’, text stored as Korean syllables do not need context-sensitive shaping to display Korean text. Nor are there any separate combining marks that would need to be positioned relative to their base character.</p>
-<p its-locale-filter-list="ko" lang="ko">많은 '복잡한 스크립트'와 달리, 한국어 음절로 저장된 텍스트는 한국어 텍스트를 표시하기 위해 문맥 의존적 렌더링 지원이 필요하지 않습니다. 또한 기본 문자를 기준으로 배치해야 하는 별도의 조합 기호도 없습니다.</p>
+<p its-locale-filter-list="ko" lang="ko">많은 다른 언어들의 '복잡한 언어 표시 방식'과 달리, 한국어 음절로 저장된 텍스트는 한국어 텍스트를 표시하기 위해 문맥 의존적 렌더링 지원이 필요하지 않습니다. 또한 기본 문자를 기준으로 배치해야 하는 별도의 조합 기호도 없습니다.</p>
 
 <p its-locale-filter-list="en" lang="en">If text is stored as jamos and composed into syllabic glyphs, then context-sensitive rendering support may be needed to assemble the jamo glyphs in the correct position within the 2-dimensional character space. However, it is more likely that jamo sequences are converted to syllabic characters before display.</p>
 <p its-locale-filter-list="ko" lang="ko">텍스트가 자모로 저장되고 음절 글꼴로 구성되는 경우, 2차원 문자 공간 내의 올바른 위치에 자모 글꼴을 조합하기 위해 문맥 의존적 렌더링 지원이 필요할 수 있습니다. 그러나 표시하기 전에 자모 시퀀스가 음절 문자로 변환될 가능성이 더 높습니다.</p>
@@ -893,7 +893,7 @@
 <p its-locale-filter-list="ko" lang="ko">원칙적으로 한국어 단어는 공백으로 구분됩니다.</p>
 
 <p its-locale-filter-list="en" lang="en">Where words written in the Latin script are followed by grammatical particles in the Korean language, there is no space between the Latin text and the following Korean characters. For more on this, see [[[#h_spacing]]].</p>
-<p its-locale-filter-list="ko" lang="ko">라틴 스크립트로 쓰인 단어 뒤에 한국어 조사가 오는 경우, 라틴 텍스트와 이어지는 한국어 문자 사이에는 공백이 없습니다. 이에 대한 자세한 내용은, [[[#h_spacing]]]을 참조하세요.</p>
+<p its-locale-filter-list="ko" lang="ko">라틴어로 쓰인 단어 뒤에 한국어 조사가 오는 경우, 라틴어 단어와 이어지는 한국어 조사 문자 사이에 공백이 없습니다. 이에 대한 자세한 내용은, [[[#h_spacing]]]을 참조하세요.</p>
 
 <p class="tbd" lang="en">TBD. This section may eventually also discuss how text is divided into graphemes, and behaviour associated with that. Are there special requirements for the following operations: forwards/backwards deletion, cursor movement &amp; selection, character counts, searching &amp; matching, text insertion, line-breaking, justification, case conversions, or sorting? Are words separated by spaces, or other characters? Are there special requirements when double-clicking or triple-clicking on the text? Are words hyphenated?</p>
 

--- a/new.html
+++ b/new.html
@@ -86,7 +86,7 @@
 
 
 <section id="contributors">
-<h2><span its-locale-filter-list="en" lang="en">Contributors</span> <span its-locale-filter-list="ko" lang="ko" class="translateme">Contributors</span></h2>
+<h2><span its-locale-filter-list="en" lang="en">Contributors</span> <span its-locale-filter-list="ko" lang="ko">기여자</span></h2>
 
 <p its-locale-filter-list="en" lang="en">This document was created by discussing the Korean related issues through Korea's Standard Infrastructure Enhancement Program and surveying needs from actual users and technical experts. The document was developed with contributions from participants of the Korean standardization committee and the Korean Society of Typography. The project to develop this document was supported by Korea's Standard Infrastructure Enhancement Program from KATS (Korean Agency for Technology and Standards).</p>
 <p its-locale-filter-list="ko" lang="ko">본 문서는 한국 기술 표준원의 표준기술력향상 사업의 지원과제를 통하여 많은 한국어 관련 이슈를 토론하고 실제 사용자와 기술적 전문가로부터 수집된 요구사항을 기반으로 작성되었다. 이 문서의 개발에는 한국 기술표준원 문서처리 표준화위원회 전문위원과 한국타이포그래피학회 회원들이 참여하였으며, 개발 작업은 기술표준원 표준기술력향상사업의 지원을 받았다.</p>
@@ -112,7 +112,7 @@
 </ol>
 
 <p its-locale-filter-list="en" lang="en">The original authors of the document were:</p>
-<p its-locale-filter-list="ko" lang="ko" class="translateme">The original authors of the document were:</p>
+<p its-locale-filter-list="ko" lang="ko">이 문서의 원저자는 다음과 같습니다:</p>
 <ul>
 <li>임순범 (Soon-Bum Lim) (숙명여자대학교 (Sookmyung Women's University))</li> 
 <li>심우진 (Wu-Jin Sim) (Invited Expert)</li> 
@@ -123,7 +123,7 @@
 </ul>
 
 <p its-locale-filter-list="en" lang="en">In 2026, the document contents were reorganised to match the standard set of headings used for the W3C's Language Enablement framework by Richard Ishida.  Additional content was then added, drawing on contributions by ...</p>
-<p its-locale-filter-list="ko" lang="ko" class="translateme">In 2026, the document contents were reorganised to match the standard set of headings used for the W3C's Language Enablement framework by Richard Ishida.  Additional content was then added, drawing on contributions by ...</p>
+<p its-locale-filter-list="ko" lang="ko">2026년에 리처드 이시다(Richard Ishida)가 W3C의 언어 지원 프레임워크에서 사용하는 표준 헤드라인 세트에 맞춰 문서 내용을 재구성했습니다. 이후 ...의 기여를 바탕으로 추가 내용이 더해졌습니다.</p>
 </section>
 
 
@@ -258,7 +258,7 @@
 <section id="h_direction">
 <h2>
 <span its-locale-filter-list="en" lang="en">Text direction</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Text direction</span>
+<span its-locale-filter-list="ko" lang="ko">텍스트 방향</span>
 </h2>
 
 
@@ -270,7 +270,7 @@
 <section id="h_writing_mode">
 <h3>
 <span its-locale-filter-list="en" lang="en">Writing mode</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Writing mode</span>
+<span its-locale-filter-list="ko" lang="ko">쓰기 모드</span>
 </h3>
 
 
@@ -484,7 +484,7 @@
 
 
 <p its-locale-filter-list="en" lang="en">See also [[[#writing-dir-mark]]].</p>
-<p its-locale-filter-list="ko" lang="ko" class="translateme">See also [[[#writing-dir-mark]]].</p>
+<p its-locale-filter-list="ko" lang="ko">참조: [[[#writing-dir-mark]]].</p>
 </section>
 
 
@@ -513,12 +513,12 @@
 <section id="h_bidi_text">
 <h3>
 <span its-locale-filter-list="en" lang="en">Bidirectional text</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Bidirectional text</span>
+<span its-locale-filter-list="ko" lang="ko">양방향 텍스트</span>
 </h3>
 
 
 <p its-locale-filter-list="en" lang="en">Modern Korean is not normally written right to left.</p>
-<p its-locale-filter-list="ko" lang="ko" class="translateme">Modern Korean is not normally written right to left.</p>
+<p its-locale-filter-list="ko" lang="ko">현대 한국어는 보통 오른쪽에서 왼쪽으로 쓰지 않습니다.</p>
 </section> 
 </section>
 
@@ -536,7 +536,7 @@
 <section id="h_shaping">
 <h2>
 <span its-locale-filter-list="en" lang="en">Glyph shaping &amp; positioning</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Glyph shaping &amp; positioning</span>
+<span its-locale-filter-list="ko" lang="ko">글자 모양 형성 및 배치</span>
 </h2>
 
 
@@ -545,7 +545,7 @@
 <section id="h_fonts">
 <h3>
 <span its-locale-filter-list="en" lang="en">Fonts &amp; typeface styles</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Fonts &amp; typeface styles</span>
+<span its-locale-filter-list="ko" lang="ko">글꼴 및 서체 스타일</span>
 </h3>
 
 
@@ -716,14 +716,14 @@
 <section id="h_context">
 <h3>
 <span its-locale-filter-list="en" lang="en">Context-based shaping &amp; positioning</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Context-based shaping &amp; positioning</span>
+<span its-locale-filter-list="ko" lang="ko">문맥 기반 모양 형성 및 배치</span>
 </h3>
 
 <p its-locale-filter-list="en" lang="en">Unlike many ‘complex scripts’, text stored as Korean syllables do not need context-sensitive shaping to display Korean text. Nor are there any separate combining marks that would need to be positioned relative to their base character.</p>
-<p its-locale-filter-list="ko" lang="ko" class="translateme">Unlike many ‘complex scripts’, text stored as Korean syllables do not need context-sensitive rendering support for displaying Korean text. Nor are there any separate combining marks that would need to be positioned relative to their base character.</p>
+<p its-locale-filter-list="ko" lang="ko">많은 '복잡한 스크립트'와 달리, 한국어 음절로 저장된 텍스트는 한국어 텍스트를 표시하기 위해 문맥 의존적 렌더링 지원이 필요하지 않습니다. 또한 기본 문자를 기준으로 배치해야 하는 별도의 조합 기호도 없습니다.</p>
 
 <p its-locale-filter-list="en" lang="en">If text is stored as jamos and composed into syllabic glyphs, then context-sensitive rendering support may be needed to assemble the jamo glyphs in the correct position within the 2-dimensional character space. However, it is more likely that jamo sequences are converted to syllabic characters before display.</p>
-<p its-locale-filter-list="ko" lang="ko" class="translateme">If text is stored as jamos and composed into syllabic glyphs, then context-sensitive rendering support may be needed to assemble the jamo glyphs in the correct position within the 2-dimensional character space. However, it is more likely that jamo sequences are converted to syllabic characters before display.</p>
+<p its-locale-filter-list="ko" lang="ko">텍스트가 자모로 저장되고 음절 글꼴로 구성되는 경우, 2차원 문자 공간 내의 올바른 위치에 자모 글꼴을 조합하기 위해 문맥 의존적 렌더링 지원이 필요할 수 있습니다. 그러나 표시하기 전에 자모 시퀀스가 음절 문자로 변환될 가능성이 더 높습니다.</p>
 </section>
 
 
@@ -739,7 +739,7 @@
 <section id="h_letterforms">
 <h3>
 <span its-locale-filter-list="en" lang="en">Letterform slopes, weights, &amp; italics</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Letterform slopes, weights, &amp; italics</span>
+<span its-locale-filter-list="ko" lang="ko">글자 기울기, 굵기 및 이탤릭</span>
 </h3>
 
 <p class="tbd" lang="en">This section will discuss whether Korean text has ways of modifying the glyphs for a range of text, such as for italicisation, bolding, oblique, etc. Content is needed.</p>
@@ -757,11 +757,11 @@
 <section id="h_cursive">
 <h3>
 <span its-locale-filter-list="en" lang="en">Cursive text</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Cursive text</span>
+<span its-locale-filter-list="ko" lang="ko">필기체 텍스트</span>
 </h3>
 
 <p its-locale-filter-list="en" lang="en">Unlike scripts such as Arabic, Adlam, and Mongolian, characters in printed Korean text aren't joined together.</p>
-<p its-locale-filter-list="ko" lang="ko" class="translateme">Unlike scripts such as Arabic, Adlam, and Mongolian, characters in printed Korean text aren't joined together.</p>
+<p its-locale-filter-list="ko" lang="ko">아랍어, 아들람어, 몽골어와 같은 스크립트와 달리 인쇄된 한국어 텍스트의 문자는 서로 연결되지 않습니다.</p>
 </section>
 
 
@@ -776,11 +776,11 @@
 <section id="h_transforms">
 <h3>
 <span its-locale-filter-list="en" lang="en">Case &amp; other character transforms</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Case &amp; other character transforms</span>
+<span its-locale-filter-list="ko" lang="ko">대소문자 및 기타 문자 변환</span>
 </h3>
 
 <p its-locale-filter-list="en" lang="en">There is no uppercase/lowercase distinction in Korean syllables, nor is there a need for conversion between halfwidth and fullwidth forms, such as in Japanese.</p>
-<p its-locale-filter-list="ko" lang="ko" class="translateme">There is no uppercase/lowercase distinction in Korean syllables, nor is there a need for conversion between halfwidth and fullwidth forms, such as in Japanese.</p>
+<p its-locale-filter-list="ko" lang="ko">한국어 음절에는 대문자와 소문자의 구분이 없으며, 일본어와 같이 반각과 전각 형태 간의 변환도 필요하지 않습니다.</p>
 </section>
 </section>
 
@@ -814,7 +814,7 @@
 <section id="h_units">
 <h2>
 <span its-locale-filter-list="en" lang="en">Typographic units</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Typographic units</span>
+<span its-locale-filter-list="ko" lang="ko">타이포그래피 단위</span>
 </h2>
 
 
@@ -822,7 +822,7 @@
 <section id="h_encoding">
 <h3>
 <span its-locale-filter-list="en" lang="en">Characters &amp; encoding</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Characters &amp; encoding</span>
+<span its-locale-filter-list="ko" lang="ko">문자 및 인코딩</span>
 </h3>
 
 <p its-locale-filter-list="en" lang="en">The characters used in Hangul Fonts consist of the following: Hangul characters, punctuation marks, Latin alphabetic characters, numbers, and special characters.</p>
@@ -886,14 +886,14 @@
 <section id="h_segmentation">
 <h3>
 <span its-locale-filter-list="en" lang="en">Grapheme/word segmentation &amp; selection</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Grapheme/word segmentation &amp; selection</span>
+<span its-locale-filter-list="ko" lang="ko">자소/단어 분절 및 선택</span>
 </h3>
 
 <p its-locale-filter-list="en" lang="en">In principle, Korean words are separated by spaces.</p>
-<p its-locale-filter-list="ko" lang="ko" class="translateme">In principle, Korean words are separated by spaces.</p>
+<p its-locale-filter-list="ko" lang="ko">원칙적으로 한국어 단어는 공백으로 구분됩니다.</p>
 
 <p its-locale-filter-list="en" lang="en">Where words written in the Latin script are followed by grammatical particles in the Korean language, there is no space between the Latin text and the following Korean characters. For more on this, see [[[#h_spacing]]].</p>
-<p its-locale-filter-list="ko" lang="ko" class="translateme">Where words written in the Latin script are followed by grammatical particles in the Korean language, there is no space between the Latin text and the following Korean characters. For more on this, see [[[#h_spacing]]].</p>
+<p its-locale-filter-list="ko" lang="ko">라틴 스크립트로 쓰인 단어 뒤에 한국어 조사가 오는 경우, 라틴 텍스트와 이어지는 한국어 문자 사이에는 공백이 없습니다. 이에 대한 자세한 내용은, [[[#h_spacing]]]을 참조하세요.</p>
 
 <p class="tbd" lang="en">TBD. This section may eventually also discuss how text is divided into graphemes, and behaviour associated with that. Are there special requirements for the following operations: forwards/backwards deletion, cursor movement &amp; selection, character counts, searching &amp; matching, text insertion, line-breaking, justification, case conversions, or sorting? Are words separated by spaces, or other characters? Are there special requirements when double-clicking or triple-clicking on the text? Are words hyphenated?</p>
 
@@ -931,7 +931,7 @@
 <section id="h_inline">
 <h2>
 <span its-locale-filter-list="en" lang="en">Punctuation &amp; inline features</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Punctuation &amp; inline features</span>
+<span its-locale-filter-list="ko" lang="ko">문장 부호 및 인라인 기능</span>
 </h2>
 
 
@@ -940,7 +940,7 @@
 <section id="h_phrase">
 <h3>
 <span its-locale-filter-list="en" lang="en">Phrase &amp; section boundaries</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Phrase &amp; section boundaries</span>
+<span its-locale-filter-list="ko" lang="ko">구절 및 섹션 경계</span>
 </h3>
 
 
@@ -1152,7 +1152,7 @@
 <section id="h_quotations">
 <h3>
 <span its-locale-filter-list="en" lang="en">Quotations &amp; citations</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Quotations &amp; citations</span>
+<span its-locale-filter-list="ko" lang="ko">인용구 및 인용 출처</span>
 </h3>
 
 
@@ -1186,7 +1186,7 @@
 <section id="h_emphasis">
 <h3>
 <span its-locale-filter-list="en" lang="en">Emphasis &amp; highlighting</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Emphasis &amp; highlighting</span>
+<span its-locale-filter-list="ko" lang="ko">강조 및 하이라이트</span>
 </h3>
 
 <p class="tbd" lang="en">TBD. How are emphasis and highlighting achieved? If lines or marks are drawn alongside, over or through the text, do they need to be a special distance from the text itself? Is it important to skip characters when underlining, etc? How do things change for vertically set text?</p>
@@ -1216,7 +1216,7 @@
 <section id="h_abbrev">
 <h3>
 <span its-locale-filter-list="en" lang="en">Abbreviation, ellipsis &amp; repetition</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Abbreviation, ellipsis &amp; repetition</span>
+<span its-locale-filter-list="ko" lang="ko">약어, 생략표 및 반복</span>
 </h3>
 
 <p class="tbd" lang="en">TBD. What characters or other methods are used to indicate abbreviation, ellipsis &amp; repetition? Are there problems?</p>
@@ -1237,7 +1237,7 @@
 <section id="h_inline_notes">
 <h3>
 <span its-locale-filter-list="en" lang="en">Inline notes &amp; annotations</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Inline notes &amp; annotations</span>
+<span its-locale-filter-list="ko" lang="ko">인라인 노트 및 주석</span>
 </h3>
 
 <p class="tbd" lang="en">TBD. What mechanisms, if any, are used to create *inline* notes and annotations? Are the appropriate methods for inline annotations supported for this script? The ruby spec currently specifies an initial subset of requirements for fine-tuning the typography of phonetic and semantic annotations of East Asian text, including furigana, pinyin and zhuyin fuhao systems. Is is useful for Korean, and adequate for what it sets out to do? What other controls will be needed in the future? What about other types of inline annotation? This section deals with inline annotation approaches. For annotation methods where a marker in the text points out to another part of the document see [[[#h_footnotes_etc]]].</p>
@@ -1268,7 +1268,7 @@
 <section id="h_text_decoration">
 <h3>
 <span its-locale-filter-list="en" lang="en">Text decoration &amp; other inline features</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Text decoration &amp; other inline features</span>
+<span its-locale-filter-list="ko" lang="ko">텍스트 장식 및 기타 인라인 기능</span>
 </h3>
 
 
@@ -1314,7 +1314,7 @@
 <section id="h_data">
 <h3>
 <span its-locale-filter-list="en" lang="en">Data formats &amp; numbers</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Data formats &amp; numbers</span>
+<span its-locale-filter-list="ko" lang="ko">데이터 형식 및 숫자</span>
 </h3>
 
 <p class="tbd" lang="en">Relevant here are formats related to number, currency, dates, personal names, addresses, and so forth. If the script has its own set of number digits, are there any issues in how they are used? Does the script or language use special format patterns that are problematic (eg. 12,34,000 in India)? What about date/time formats and selection - and are non-Gregorian calendars needed? Do percent signs and other symbols associated with number work correctly, and do numbers need special decorations, (like in Ethiopic or Syriac)? How about the management of personal names, addresses, etc. in web pages: are there issues?</p>
@@ -1345,7 +1345,7 @@
 <section id="h_para">
 <h2>
 <span its-locale-filter-list="en" lang="en">Line &amp; paragraph layout</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Line &amp; paragraph layout</span>
+<span its-locale-filter-list="ko" lang="ko">행 및 단락 레이아웃</span>
 </h2>
 
 
@@ -1357,7 +1357,7 @@
 <section id="h_line_breaking">
 <h3>
 <span its-locale-filter-list="en" lang="en">Line breaking &amp; hyphenation</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Line breaking &amp; hyphenation</span>
+<span its-locale-filter-list="ko" lang="ko">줄 바꿈 및 하이픈 연결</span>
 </h3>
 
 
@@ -1496,7 +1496,7 @@
 <section id="h_justification">
 <h3>
 <span its-locale-filter-list="en" lang="en">Text alignment &amp; justification</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Text alignment &amp; justification</span>
+<span its-locale-filter-list="ko" lang="ko">텍스트 정렬 및 양끝 맞춤</span>
 </h3>
 
 
@@ -1736,7 +1736,7 @@
 <section id="h_spacing">
 <h3>
 <span its-locale-filter-list="en" lang="en">Text spacing</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Text spacing</span>
+<span its-locale-filter-list="ko" lang="ko">글자 간격</span>
 </h3>
 
 
@@ -1844,7 +1844,7 @@
 <section id="h_baselines">
 <h3>
 <span its-locale-filter-list="en" lang="en">Baselines, line height, etc.</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Baselines, line height, etc.</span>
+<span its-locale-filter-list="ko" lang="ko">기준선, 행 높이 등</span>
 </h3>
 
 
@@ -1918,7 +1918,7 @@
 <section id="h_lists">
 <h3>
 <span its-locale-filter-list="en" lang="en">Lists, counters, etc.</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Lists, counters, etc.</span>
+<span its-locale-filter-list="ko" lang="ko">목록, 카운터 등</span>
 </h3>
 
 <p class="tbd" lang="en">TBD. See <a href="https://www.w3.org/TR/predefined-counter-styles/#korean-styles">Ready-made Counter Styles</a> Are there other counter styles in use? Are there preferred styles for particular contexts? Are the correct separators available for use after list counters? Are there other aspects related to counters and lists that need to be addressed? How do list counters differ for use with vertical text?</p>
@@ -1948,7 +1948,7 @@
 <section id="h_initials">
 <h3>
 <span its-locale-filter-list="en" lang="en">Styling initials</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Styling initials</span>
+<span its-locale-filter-list="ko" lang="ko">첫 글자 스타일 지정</span>
 </h3>
 
 <p class="tbd" lang="en">TBD. Does Korean use large font sizes for initial characters in an article or section? If so, is the height typically dropped into the paragraph or does it create a larger pre-paragraph gap?  What is the size relationship between the large letter(s) and the lines alongside? Where does the large letter anchor relative to the lines alongside? Is it normal to include initial quote marks or other punctuation in the large letter? Is the large letter sometimes a sequence of letters?</p>
@@ -1973,7 +1973,7 @@
 <section id="h_page">
 <h2>
 <span its-locale-filter-list="en" lang="en">Page &amp; book layout</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Page &amp; book layout</span>
+<span its-locale-filter-list="ko" lang="ko">페이지 및 서적 레이아웃</span>
 </h2>
 
 
@@ -1987,7 +1987,7 @@
 <section id="h_page_layout">
 <h3>
 <span its-locale-filter-list="en" lang="en">General page layout &amp; progression</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">General page layout &amp; progression</span>
+<span its-locale-filter-list="ko" lang="ko">일반 페이지 레이아웃 및 진행 방향</span>
 </h3>
 
 
@@ -2475,7 +2475,7 @@
 <section id="h_grids_tables">
 <h3>
 <span its-locale-filter-list="en" lang="en">Grids &amp; tables</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Grids &amp; tables</span>
+<span its-locale-filter-list="ko" lang="ko">그리드 및 표</span>
 </h3>
 
 
@@ -2583,7 +2583,7 @@
 <section id="h_footnotes_etc">
 <h3>
 <span its-locale-filter-list="en" lang="en">Footnotes, endnotes, etc.</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Footnotes, endnotes, etc.</span>
+<span its-locale-filter-list="ko" lang="ko">각주, 미주 등</span>
 </h3>
 
 
@@ -2749,7 +2749,7 @@
 <section id="h_headers_footers">
 <h3>
 <span its-locale-filter-list="en" lang="en">Page headers, footers, etc.</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Page headers, footers, etc.</span>
+<span its-locale-filter-list="ko" lang="ko">페이지 머리글, 바닥글 등</span>
 </h3>
 
 
@@ -2803,7 +2803,7 @@
 <section id="h_interaction">
 <h3>
 <span its-locale-filter-list="en" lang="en">Forms &amp; user interaction</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Forms &amp; user interaction</span>
+<span its-locale-filter-list="ko" lang="ko">양식 및 사용자 상호작용</span>
 </h3>
 
 <p class="tbd" lang="en">Are vertical form controls well supported? Are there other aspects related to user interaction that need to be addressed?</p>
@@ -3201,7 +3201,7 @@
 
 <section class="appendix" id="app-d">
 <h2><span its-locale-filter-list="en" lang="en">Hangul Typographic Classes</span>
-<span its-locale-filter-list="ko" lang="ko" class="translateme">Hangul Typographic Classes</span></h2>
+<span its-locale-filter-list="ko" lang="ko">한글 타이포그래피 분류</span></h2>
 
 <p its-locale-filter-list="en" lang="en">In a Hangul environment, characters and symbols are classified by typographic characteristics, into 32 classes.</p>
 <p its-locale-filter-list="ko" lang="ko">한글 환경에서 문자와 기호는 타이포그래픽 특성에 따라 괄호, 하이픈, 문장구분 기호 등 32가지로 구분한다.</p>


### PR DESCRIPTION
Translate English text to Korean for 45 'translateme' class elements, then delete the attribute.

The previous PR (#72) utilized BeautifulSoup for the automatic script, but it made unnecessary empty line removal and reordered attributed. Hence, I handled it with RE-based script that worked only for the Korean translation.
https://www.online-python.com/EQmuPCASIT

Fixes #70 